### PR TITLE
Corrected URL in Git clone message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Getting Started
 ```
-$ git clone git@github.com:Can-I-Vote-If/can-i-vote-if.git
+$ git clone https://github.com/Can-I-Vote-If/can-i-vote-if.git
 $ cd can-i-vote-if
 $ yarn
 $ yarn start


### PR DESCRIPTION
The URL provided in the "git clone" message didn't work for me.  The new one that I'm pushing does.